### PR TITLE
Updated strings for Gingerbread

### DIFF
--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -8,7 +8,7 @@
     <string name="deny">Zakázat</string>
     <string name="remember">Zapamatovat</string>
     <string name="uid">(uid: %d)</string>
-    <string name="request">%s jako %s (uid: %d)</string>
+    <string name="request">%1$s jako %2$s (uid: %3$d)</string>
     <string name="detail_package">Balík:</string>
     <string name="detail_request">Požadované UID:</string>
     <string name="detail_command">Příkaz:</string>

--- a/res/values-da/strings.xml
+++ b/res/values-da/strings.xml
@@ -12,7 +12,7 @@
     <string name="deny">Afvis</string>
     <string name="remember">Husk</string>
     <string name="uid">(uid: %d)</string>
-    <string name="request">%s som %s (uid: %d)</string>
+    <string name="request">%1$s som %2$s (uid: %3$d)</string>
     <string name="unknown">Ukendt navn</string>
 
     <string name="allowed">Godkendt</string>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -21,7 +21,7 @@
     <string name="deny">Verweigern</string>
     <string name="remember">Merken</string>
     <string name="uid">(uid: %d)</string>
-    <string name="request">%s als %s (uid: %d)</string>
+    <string name="request">%1$s als %2$s (uid: %3$d)</string>
     <string name="unknown">Unbekannter Name</string>
 
     <string name="allowed">Erlaubt</string>

--- a/res/values-el/strings.xml
+++ b/res/values-el/strings.xml
@@ -8,7 +8,7 @@
     <string name="deny">Άκυρο</string>
     <string name="remember">Αποθήκευση</string>
     <string name="uid">(uid: %d)</string>
-    <string name="request">%s as %s (uid: %d)</string>
+    <string name="request">%1$s as %2$s (uid: %3$d)</string>
     <string name="detail_package">Πακέτο:</string>
     <string name="detail_request">Αίτηση από UID:</string>
     <string name="detail_command">Εντολή:</string>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -8,7 +8,7 @@
     <string name="deny">Denegar</string>
     <string name="remember">Recordar</string>
     <string name="uid">(uid: %d)</string>
-    <string name="request">%s es %s (uid: %d)</string>
+    <string name="request">%1$s es %2$s (uid: %3$d)</string>
     <string name="detail_package">Paquete:</string>
     <string name="detail_request">UID solicitado:</string>
     <string name="detail_command">Comando:</string>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -25,7 +25,7 @@
     <string name="deny">Refuser</string>
     <string name="remember">Se souvenir</string>
     <string name="uid">(idu: %d)</string>
-    <string name="request">%s en tant que %s (idu : %d)</string>
+    <string name="request">%1$s en tant que %2$s (idu : %3$d)</string>
     <string name="unknown">Nom inconnu</string>
 
     <string name="allowed">Autorisé</string>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -18,7 +18,7 @@
     <string name="deny">Nega</string>
     <string name="remember">Ricorda</string>
     <string name="uid">(uid: %d)</string>
-    <string name="request">%s as %s (uid: %d)</string>
+    <string name="request">%1$s as %2$s (uid: %3$d)</string>
     <string name="unknown">Unknown name</string>
 
     <string name="allowed">Consentito</string>

--- a/res/values-ja/strings.xml
+++ b/res/values-ja/strings.xml
@@ -10,7 +10,7 @@
     <string name="deny">拒否</string>
     <string name="remember">記憶する</string>
     <string name="uid">(uid: %d)</string>
-    <string name="request">%s as %s (uid: %d)</string>
+    <string name="request">%1$s as %2$s (uid: %3$d)</string>
     <string name="detail_package">パッケージ:</string>
     <string name="detail_request">要求 UID:</string>
     <string name="detail_command">コマンド:</string>

--- a/res/values-nl/strings.xml
+++ b/res/values-nl/strings.xml
@@ -8,7 +8,7 @@
     <string name="deny">Weigeren</string>
     <string name="remember">Onthouden</string>
     <string name="uid">(uid: %d)</string>
-    <string name="request">%s als %s (uid: %d)</string>
+    <string name="request">%1$s als %2$s (uid: %3$d)</string>
     <string name="detail_package">Package:</string>
     <string name="detail_request">Aangevraagd UID:</string>
     <string name="detail_command">Commando:</string>

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -14,7 +14,7 @@
     <string name="deny">Odmów</string>
     <string name="remember">Zapamiętaj</string>
     <string name="uid">(uid: %d)</string>
-    <string name="request">%s jako %s (uid: %d)</string>
+    <string name="request">%1$s jako %2$s (uid: %3$d)</string>
     <string name="unknown">Nieznana nazwa</string>
     <string name="allowed">Zezwolony</string>
     <string name="denied">Odmowa</string>

--- a/res/values-pt-rBR/strings.xml
+++ b/res/values-pt-rBR/strings.xml
@@ -12,7 +12,7 @@
     <string name="deny">Negar</string>
     <string name="remember">Lembrar</string>
     <string name="uid">(uid: %d)</string>
-    <string name="request">%s como %s (uid: %d)</string>
+    <string name="request">%1$s como %2$s (uid: %3$d)</string>
     <string name="unknown">Nome desconhecido</string>
 
     <string name="allowed">Permitido</string>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -16,7 +16,7 @@
     <string name="deny">Запретить</string>
     <string name="remember">Запомнить</string>
     <string name="uid">(uid: %d)</string>
-    <string name="request">%s как %s (uid: %d)</string>
+    <string name="request">%1$s как %2$s (uid: %3$d)</string>
     <string name="unknown">Unknown name</string>
 
     <string name="allowed">Разрешено</string>

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -34,7 +34,7 @@
     <string name="deny">拒绝</string>
     <string name="remember">记住</string>
     <string name="uid">(uid: %d)</string>
-    <string name="request">%s 作为 %s (uid: %d)</string>
+    <string name="request">%1$s 作为 %2$s (uid: %3$d)</string>
     <string name="unknown">未知名称</string>
     <string name="allowed">被允许</string>
     <string name="denied">被拒绝</string>

--- a/res/values-zh-rTW/strings.xml
+++ b/res/values-zh-rTW/strings.xml
@@ -34,7 +34,7 @@
     <string name="deny">拒絕</string>
     <string name="remember">記住</string>
     <string name="uid">(uid: %d)</string>
-    <string name="request">%s 作為 %s (uid: %d)</string>
+    <string name="request">%1$s 作為 %2$s (uid: %3$d)</string>
     <string name="unknown">未知名稱</string>
     <string name="allowed">被允許</string>
     <string name="denied">被拒絕</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -37,7 +37,7 @@
     <string name="deny">Deny</string>
     <string name="remember">Remember</string>
     <string name="uid">(uid: %d)</string>
-    <string name="request">%s as %s (uid: %d)</string>
+    <string name="request">%1$s as %2$s (uid: %3$d)</string>
     <string name="unknown">Unknown name</string>
 
     <string name="allowed">Allowed</string>


### PR DESCRIPTION
There were some compile errors compiling with Gingerbread and I found out that multiple substitutions now have to be something like %1$s %2$s etc.
