### PR TITLE
su binary update support for Archos Gen8 devices

### DIFF
--- a/src/com/noshufou/android/su/UpdaterFragment.java
+++ b/src/com/noshufou/android/su/UpdaterFragment.java
@@ -771,7 +771,10 @@ public class UpdaterFragment extends ListFragment implements OnClickListener {
             Log.e(TAG, "Busybox not present");
             return null;
         }
-        
+
+        if(new File("/system/bin/su").exists()) {
+          return "/system/bin/su";
+        }
         Process process = null;
         try {
             String cmd = mBusyboxPath + " which su";


### PR DESCRIPTION
Hi ChainsDD

On XDA, I made a package to root the Archos Gen8 tablets. Now, after your Superuser app supports auto-update of the su binary, my users ran into the problem, that the app will not be able to determine the su binary location because the busybox Archos' stock firmare uses is garbage (it doesn't support the 'which' command).

This patch would solve this problem in an easy but not yet very beautiful way. Maybe you have a better idea as you have more understanding of Androids internals.

Best regards, chrulri
