### PR TITLE
Fix a couple errors

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -135,12 +135,6 @@
                 <data android:scheme="package" />
             </intent-filter>
         </receiver>
-        <receiver android:name="UpdatePermissionsReceiver">
-            <intent-filter>
-                <action android:name="com.noshufou.android.su.UPDATE_PERMISSIONS" />
-                <action android:name="android.intent.action.BOOT_COMPLETED" />
-            </intent-filter>
-        </receiver>
         
         <service android:name=".service.ResultService" />
         <service android:name=".service.PermissionsDbService" />

--- a/res/values-bg/strings.xml
+++ b/res/values-bg/strings.xml
@@ -55,7 +55,6 @@
   <string name="detail_request">Искан UID</string>
   <string name="detail_command">Команда</string>
   <string name="detail_status">Състояние</string>
-  <string name="info_elite_installed">елит е инсталирана</string>
   <string name="info_display_changelog">щракнете за промените</string>
   <string name="info_elite_installed">елит е инсталирана</string>
   <string name="info_elite_not_installed">елит не е инсталирана</string>

--- a/res/values-da/strings.xml
+++ b/res/values-da/strings.xml
@@ -55,7 +55,6 @@
   <string name="detail_request">Anmodet UID</string>
   <string name="detail_command">Kommando</string>
   <string name="detail_status">Status</string>
-  <string name="info_elite_installed">elite er installeret</string>
   <string name="info_display_changelog">Tryk for at vise changelog</string>
   <string name="info_elite_installed">elite er installeret</string>
   <string name="info_elite_not_installed">elite er ikke installeret</string>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -55,7 +55,6 @@
   <string name="detail_request">Angeforderte UID</string>
   <string name="detail_command">Befehl</string>
   <string name="detail_status">Status</string>
-  <string name="info_elite_installed">Elite installiert</string>
   <string name="info_display_changelog">Drücken um Changelog anzuzeigen</string>
   <string name="info_elite_installed">Elite installiert</string>
   <string name="info_elite_not_installed">Elite nicht installiert</string>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -55,7 +55,6 @@
   <string name="detail_request">UID solicitada</string>
   <string name="detail_command">Comando</string>
   <string name="detail_status">Estado</string>
-  <string name="info_elite_installed">elite instalado</string>
   <string name="info_display_changelog">pulse para mostrar el registro de cambios</string>
   <string name="info_elite_installed">elite instalado</string>
   <string name="info_elite_not_installed">elite no instalado</string>

--- a/res/values-fi/strings.xml
+++ b/res/values-fi/strings.xml
@@ -55,7 +55,6 @@
   <string name="detail_request">Pyydetty UID</string>
   <string name="detail_command">Komento</string>
   <string name="detail_status">Tila</string>
-  <string name="info_elite_installed">elite on asennettu</string>
   <string name="info_display_changelog">napauta nähdäksesi muutoslokin</string>
   <string name="info_elite_installed">elite on asennettu</string>
   <string name="info_elite_not_installed">elite ei ole asennettu</string>

--- a/res/values-ko/strings.xml
+++ b/res/values-ko/strings.xml
@@ -55,7 +55,6 @@
   <string name="detail_request">요청된 UID</string>
   <string name="detail_command">명령</string>
   <string name="detail_status">상태</string>
-  <string name="info_elite_installed">Elite 버전 설치됨</string>
   <string name="info_display_changelog">터치하여 변경 내역 표시</string>
   <string name="info_elite_installed">Elite 버전 설치됨</string>
   <string name="info_elite_not_installed">Elite 버전 미설치</string>

--- a/res/values-no/strings.xml
+++ b/res/values-no/strings.xml
@@ -55,7 +55,6 @@
   <string name="detail_request">UID forespurt</string>
   <string name="detail_command">Kommando</string>
   <string name="detail_status">Status</string>
-  <string name="info_elite_installed">Elite installert</string>
   <string name="info_display_changelog">Trykk for å vise versjonshistorie</string>
   <string name="info_elite_installed">Elite installert</string>
   <string name="info_elite_not_installed">Elite ikke installert</string>

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -55,7 +55,6 @@
   <string name="detail_request">Żądane UID</string>
   <string name="detail_command">Polecenie</string>
   <string name="detail_status">Status</string>
-  <string name="info_elite_installed">Wersja Elite zainstalowana</string>
   <string name="info_display_changelog">Puknij aby wyświetlić listę zmian</string>
   <string name="info_elite_installed">Wersja Elite zainstalowana</string>
   <string name="info_elite_not_installed">Wersja Elite nie jest zainstalowana</string>

--- a/res/values-pt-rBR/strings.xml
+++ b/res/values-pt-rBR/strings.xml
@@ -55,7 +55,6 @@
   <string name="detail_request">UID requisitado:</string>
   <string name="detail_command">Comando:</string>
   <string name="detail_status">Estado:</string>
-  <string name="info_elite_installed">Elite instalado</string>
   <string name="info_display_changelog">toque para exibir changelog</string>
   <string name="info_elite_installed">Elite instalado</string>
   <string name="info_elite_not_installed">Elite não instalado</string>

--- a/res/values-pt-rPT/strings.xml
+++ b/res/values-pt-rPT/strings.xml
@@ -55,7 +55,6 @@
   <string name="detail_request">UID requisitado:</string>
   <string name="detail_command">Comando</string>
   <string name="detail_status">Estado</string>
-  <string name="info_elite_installed">versão elite instalada</string>
   <string name="info_display_changelog">toque para mostrar o changelog</string>
   <string name="info_elite_installed">versão elite instalada</string>
   <string name="info_elite_not_installed">versão elite não instalada</string>

--- a/res/values-sk/strings.xml
+++ b/res/values-sk/strings.xml
@@ -55,7 +55,6 @@
   <string name="detail_request">Požadované UID</string>
   <string name="detail_command">Príkaz</string>
   <string name="detail_status">Stav</string>
-  <string name="info_elite_installed">Elite nainštalovaný</string>
   <string name="info_display_changelog">kliknite pre zobrazenie zmien</string>
   <string name="info_elite_installed">Elite nainštalovaný</string>
   <string name="info_elite_not_installed">Elit nie je nainštalovaný</string>

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -55,7 +55,6 @@
   <string name="detail_request">请求 UID</string>
   <string name="detail_command">命令</string>
   <string name="detail_status">状态</string>
-  <string name="info_elite_installed">精英版已安装</string>
   <string name="info_display_changelog">点击此处查看更新日志</string>
   <string name="info_elite_installed">精英版已安装</string>
   <string name="info_elite_not_installed">未安装精英版</string>

--- a/res/values-zh-rTW/strings.xml
+++ b/res/values-zh-rTW/strings.xml
@@ -55,7 +55,6 @@
   <string name="detail_request">請求 UID</string>
   <string name="detail_command">命令</string>
   <string name="detail_status">狀態</string>
-  <string name="info_elite_installed">精英版已安裝</string>
   <string name="info_display_changelog">點擊顯示更新紀錄</string>
   <string name="info_elite_installed">精英版已安裝</string>
   <string name="info_elite_not_installed">精英版未安裝</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -81,7 +81,6 @@
     <string name="detail_command">Command</string>
     <string name="detail_status">Status</string>
     
-    <string name="info_elite_installed">elite installed</string>
     <string name="info_display_changelog">tap to display changelog</string>
     <string name="info_elite_installed">elite installed</string>
     <string name="info_elite_not_installed">elite not installed</string>

--- a/src/com/noshufou/android/su/InfoFragment.java
+++ b/src/com/noshufou/android/su/InfoFragment.java
@@ -268,7 +268,7 @@ public class InfoFragment extends SherlockFragment
                     mOutdatedNotification.setChecked((Boolean) values[1]);
                     break;
                 case 5:
-                    if (values[0] == null) {
+                    if (values[1] == null) {
                         mSuOptionsRow.setVisibility(View.GONE);
                     } else {
                         boolean rooted = (Boolean) values[1];


### PR DESCRIPTION
Remove duplicate strings for "info_elite_installed" in various translations to resolve build errors.

Check the correct array index to fix an NPE.

Remove UpdatePermissionsReceiver from the manifest since that functionality was removed in a previous commit and causes a FC on BOOT_COMPLETED.
